### PR TITLE
Split into a library and a binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "unciv"
-version = "0.1.0"
+description = "Library and tools for reading the Call To Power game data files"
+homepage = "https://davidgow.net/hacks/unciv.html"
+repository = "https://github.com/sulix/unciv"
+license-file = "LICENSE"
+version = "0.2.0"
 edition = "2015"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,3 +15,4 @@ set-timestamps = []
 [dependencies]
 byteorder = "1.3"
 png = "0.15"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ edition = "2015"
 set-timestamps = []
 
 [dependencies]
-byteorder = "1.3"
 png = "0.15"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2015"
 set-timestamps = []
 
 [dependencies]
-png = "0.15"
+png = { version = "0.15", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ In particular, it extracts the game's zfs archives, which contain the majority
 of the miscellaneous graphics (everything except tiles, sprites, and a few
 things like mouse cursors), as well as the sounds.
 
-unciv also converts the game's rim graphics format to PNG, including both the
-555 and 565 variants.
+unciv can also convert the game's rim graphics format to PNG, including both
+the 555 and 565 variants.
 
 ## Usage
 
@@ -22,29 +22,64 @@ cargo run <path to .zfs file>
 
 The contents of the .zfs file will be extracted into the current directory.
 
-Any file in the archive with the extension ``rim`` will be converted to a .png
-when extracted.
+To convert .rim files to .png, you will need the ``png`` crate, and to enable
+the ``png`` feature, with:
+```
+cargo run --features png <path to .zfs file>
+```
 
-If you wish for the original timestamps to be preserved, and you're running a
-nightly build of Rust with the ``file_set_times`` supported, you can use
+Any file in the archive with the extension ``rim`` will then be converted to a
+.png when extracted.
+
+If you wish for the original timestamps to be preserved, and you're running
+Rust v1.75 or newer (or a nightly build of Rust with the ``file_set_times``
+feature supported), you can use
 ```
 cargo run --features set-timestamps <path to .zfs file>
 ```
 
+The ``png`` and ``set-timestamps`` features can be combined.
+
+## Usage as a Library
+
+``unciv`` can also be used as a Rust library to parse and read ``.zfs`` files,
+and the ``rim`` files within them.
+
+To load a ``.zfs`` file, you'll need to use the ``ZfsFile::from_stream()``
+function. The resulting ``ZfsFile`` struct has a ``Vec`` of ``ZfsEntry``
+structs, upon which either ``read_data()`` can be called to retrieve the
+contents of the file, or ``read_rim_image()`` to retrieve it in the form of a
+``RimImage`` struct.
+
+The ``RimImage`` struct contains information like the width and height, as
+well as the raw data. Alternatively, the ``to_rgba_bytes()`` function can be
+used to convert the data to 32-bit RGBA format.
+
+You can get the library's documentation using ``cargo doc``, or you can look
+at ``src/main.rs`` — the source code for the command-line utility — which
+serves as a good example of the API.
+
 ## Building
 
-unciv depends on the byteorder (v1.3+) and png (v0.15) crates. Note that png has
-an absolute boatload of dependencies of its own, so you'll need to get those
-via cargo or some other means.
+unciv depends on the png (v0.15) crate. Note that png has an absolute boatload
+of dependencies of its own, so you'll need to get those via cargo or some other
+means.
 
 It's possible to build unciv with the rustc version included with Debian, just
 install
 ```
-sudo apt install rustc cargo librust-byteorder-dev librust-png+deflate-dev
+sudo apt install rustc cargo librust-png+deflate-dev
 ```
 
 You can use Debian's packaged crates by following the [Debian Wiki](https://wiki.debian.org/Rust).
 
+Note, however, that version 0.15 of png is only available in Debian bullseye.
+This does mean that building ``unciv`` on newer versions of Debian requires
+updating the ``png`` dependency to version 0.17 (even if the ``png`` feature is
+disabled, as the generation of ``Cargo.lock`` apparently requires the version
+to exist in the repository even if it isn't used). This can be done by just
+changing the version in ``Cargo.toml``, and replacing ``RGBA`` with ``Rgba``
+in ``src/main.rs``, which is the only change required.
 
 Have fun!
 — David

--- a/src/binary_io.rs
+++ b/src/binary_io.rs
@@ -1,0 +1,73 @@
+/*
+ * unciv: An extractor for Civilization: Call to Power's zfs files.
+ *
+ * Copyright (c) 2025, David Gow <david@davidgow.net>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+ * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#![allow(dead_code)]
+
+pub fn read_byte(reader: &mut dyn std::io::Read) -> std::io::Result<u8> {
+    let mut out_byte: u8 = 0;
+    reader.read_exact(std::slice::from_mut(&mut out_byte))?;
+    return Ok(out_byte);
+}
+
+pub fn read_le16(reader: &mut dyn std::io::Read) -> std::io::Result<u16> {
+    let mut raw_bytes = [0 as u8; 2];
+    reader.read_exact(&mut raw_bytes)?;
+    return Ok(u16::from_le_bytes(raw_bytes));
+}
+
+pub fn read_le32(reader: &mut dyn std::io::Read) -> std::io::Result<u32> {
+    let mut raw_bytes = [0 as u8; 4];
+    reader.read_exact(&mut raw_bytes)?;
+    return Ok(u32::from_le_bytes(raw_bytes));
+}
+
+pub fn read_be16(reader: &mut dyn std::io::Read) -> std::io::Result<u16> {
+    let mut raw_bytes = [0 as u8; 2];
+    reader.read_exact(&mut raw_bytes)?;
+    return Ok(u16::from_be_bytes(raw_bytes));
+}
+
+pub fn read_be32(reader: &mut dyn std::io::Read) -> std::io::Result<u32> {
+    let mut raw_bytes = [0 as u8; 4];
+    reader.read_exact(&mut raw_bytes)?;
+    return Ok(u32::from_be_bytes(raw_bytes));
+}
+
+pub fn write_byte(out_byte: u8, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    writer.write_all(std::slice::from_ref(&out_byte))
+}
+
+pub fn write_be16(out_val: u16, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    let raw_bytes = out_val.to_be_bytes();
+    writer.write_all(&raw_bytes)
+}
+
+pub fn write_be32(out_val: u32, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    let raw_bytes = out_val.to_be_bytes();
+    writer.write_all(&raw_bytes)
+}
+
+pub fn write_le16(out_val: u16, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    let raw_bytes = out_val.to_le_bytes();
+    writer.write_all(&raw_bytes)
+}
+
+pub fn write_le32(out_val: u32, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    let raw_bytes = out_val.to_le_bytes();
+    writer.write_all(&raw_bytes)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,252 @@
+/*
+ * unciv: An extractor for Civilization: Call to Power's zfs files.
+ *
+ * Copyright (c) 2023, David Gow <david@davidgow.net>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+ * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+
+extern crate byteorder;
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::Seek;
+use std::io;
+use std::io::Read;
+
+#[repr(u16)]
+/// The pixel format of a RIM image
+pub enum RimFormat
+{
+    /// 16-bit RGB, with 1 ignored, 5 red, 5 green, and 5 blue bits.
+    RGB555 = 0,
+    /// 16-bit RGB, with 5 red, 6 green, and 5 blue bits.
+    RGB565 = 1,
+}
+
+/// The FOURCC signature of a RIM file, 'RIMF'
+pub const RIM_SIGNATURE : u32 = 0x464d4952;
+
+/// An image in RIM format, including any data.
+pub struct RimImage
+{
+    /// The file version, always 0
+    pub ver : u32,
+    /// The width of the image, in pixels
+    pub width : u16,
+    /// The height of the image, in pixels
+    pub height : u16,
+    /// The pitch of the image, in bytes
+    pub pitch : u16,
+    /// The pixel format of the image. Always 16-bit.
+    pub fmt : RimFormat,
+    /// The raw pixel data of the image, as width*height u16s.
+    pub data : Vec<u16>,
+}
+
+impl RimImage {
+    /// Read a RimHeader from a stream. Image data immediately follows.
+    pub fn from_stream(reader: &mut (impl Read + Seek)) -> std::io::Result<RimImage> {
+        let rim_sig = reader.read_u32::<LittleEndian>()?;
+
+        // 'RIMF'
+        if rim_sig != RIM_SIGNATURE {
+            return Err(io::Error::new(io::ErrorKind::Other, "Invalid RIM signature"));
+        }
+
+        let rim_ver = reader.read_u32::<LittleEndian>()?;
+        let rim_width = reader.read_u16::<LittleEndian>()?;
+        let rim_height = reader.read_u16::<LittleEndian>()?;
+        let rim_pitch = reader.read_u16::<LittleEndian>()?;
+        let rim_fmt = reader.read_u16::<LittleEndian>()?;
+
+        let fmt = match rim_fmt {
+            0 => RimFormat::RGB555,
+            1 => RimFormat::RGB565,
+            _ => { return Err(std::io::Error::new(io::ErrorKind::Other, "Unknown RIM format")); }
+        };
+
+        let num_pixels = rim_width as usize * rim_height as usize;
+        let mut data = Vec::<u16>::with_capacity(num_pixels);
+        for _line_num in 0..rim_height {
+            for _px in 0..rim_width {
+                data.push(reader.read_u16::<LittleEndian>()?);
+            }
+
+            if rim_width * 2 != rim_pitch {
+                reader.seek(io::SeekFrom::Current((rim_pitch - rim_width * 2) as i64))?;
+            }
+        }
+
+        Ok(RimImage {
+            ver: rim_ver,
+            width: rim_width,
+            height: rim_height,
+            pitch: rim_pitch,
+            fmt,
+            data,
+        })
+    }
+
+    /// Reads the image data for a RIM image, converting it to 32-bit RGBA data.
+    pub fn to_rgba_bytes(&self) -> Vec<u8> {
+        let num_pixels = self.width as usize * self.height as usize;
+        let mut data = Vec::<u8>::with_capacity(num_pixels * 4);
+        let mut i = 0;
+        for _line_num in 0..self.height {
+            for _px in 0..self.width {
+                match self.fmt {
+                    RimFormat::RGB555 => {
+                        // 555
+                        let px555 = self.data[i];
+                        let red = (px555 >> 10) & 31;
+                        let green = (px555 >> 5) & 31;
+                        let blue = (px555 >> 0) & 31;
+                        data.push((red << 3) as u8);
+                        data.push((green << 3) as u8);
+                        data.push((blue << 3) as u8);
+                        data.push(255);
+                        i += 1;
+                    },
+                    RimFormat::RGB565 => {
+                        // 565
+                        let px565 = self.data[i];
+                        let red = (px565 >> 11) & 31;
+                        let green = (px565 >> 5) & 63;
+                        let blue = (px565 >> 0) & 31;
+                        data.push((red << 3) as u8);
+                        data.push((green << 2) as u8);
+                        data.push((blue << 3) as u8);
+                        data.push(255);
+                        i += 1;
+                    },
+                }
+            }
+        }
+        data
+    }
+}
+
+/// Represents a single entry in a ZFS file.
+#[derive(Clone)]
+pub struct ZfsEntry
+{
+    /// The filename of the entry.
+    pub name : String,
+    /// The offset, in bytes, of the file data from the start of the ZFS file.
+    pub offset : usize,
+    /// The size, in bytes, of the file.
+    pub size : usize,
+    /// The timestamp of the file.
+    pub timestamp : std::time::SystemTime,
+    /// Flags stored in the entry header
+    pub flags : u32,
+}
+
+impl ZfsEntry
+{
+    /// Read the contents of an entry.
+    ///
+    /// # Arguments
+    ///
+    /// - reader: A reader for the whole ZFS file. This needs to implement Seek, as
+    ///    get_data() will seek to the start of the entry's data before reading.
+    pub fn read_data(&self, reader : &mut (impl Read + Seek)) -> io::Result<Vec<u8>> {
+        let mut buffer = vec![0; self.size];
+        reader.seek(io::SeekFrom::Start(self.offset as u64))?;
+        reader.read(&mut buffer)?;
+        Ok(buffer)
+    }
+    
+    pub fn read_rim_image(&self, reader : &mut (impl Read + Seek)) -> io::Result<RimImage> {
+        reader.seek(io::SeekFrom::Start(self.offset as u64))?;
+        let rim_image = RimImage::from_stream(reader)?;
+        Ok(rim_image)
+    }
+}
+
+/// The FOURCC signature of a ZFS file, 'ZFS3
+pub const ZFS_SIGNATURE : u32 = 0x3353465a;
+
+
+/// Represents the headers of a ZFS file.
+///
+/// Unlike ZfsFile, this does not maintain a reference to the data, or the
+/// underlying file. Any functions which access the data will need to provide
+/// a reader.
+pub struct ZfsFile
+{
+    pub version : u32,
+    pub max_filename_len : u32,
+    pub files : Vec::<ZfsEntry>,
+}
+
+impl ZfsFile {
+    pub fn from_stream(reader : &mut (impl Read + Seek)) -> io::Result<ZfsFile> {
+        let sig = reader.read_u32::<LittleEndian>()?;
+        // 'ZFS3'
+        if sig != ZFS_SIGNATURE {
+            return Err(io::Error::new(io::ErrorKind::Other, "Invalid ZFS signature"));
+        }
+        let version = reader.read_u32::<LittleEndian>()?;
+        let max_filename_len = reader.read_u32::<LittleEndian>()?;
+        let files_per_table = reader.read_u32::<LittleEndian>()?;
+        let num_files = reader.read_u32::<LittleEndian>()?;
+        let _unk2 = reader.read_u32::<LittleEndian>()?;
+        let filetable_offset = reader.read_u32::<LittleEndian>()?;
+
+
+        let mut files = Vec::<ZfsEntry>::new();
+
+        reader.seek(io::SeekFrom::Start(filetable_offset as u64))?;
+
+        let mut next_table_offset = reader.read_u32::<LittleEndian>()?;
+        for i in 0..num_files {
+            let mut raw_name = vec![0; max_filename_len as usize];
+            reader.read_exact(&mut raw_name)?;
+
+            if raw_name[0] == 0 {
+                break;
+            }
+
+            let file_name = String::from_utf8_lossy(&raw_name);
+            let file_name = file_name.trim_matches('\0');
+            let data_offset = reader.read_u32::<LittleEndian>()?;
+            let _unk3 = reader.read_u32::<LittleEndian>()?;
+            let data_size = reader.read_u32::<LittleEndian>()?;
+            let timestamp = reader.read_u32::<LittleEndian>()?;
+            let flags = reader.read_u32::<LittleEndian>()?;
+
+            files.push(ZfsEntry{
+                name : file_name.to_string(),
+                offset : data_offset as usize,
+                size : data_size as usize,
+                timestamp: std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp as u64),
+                flags
+            });
+
+            if (i % files_per_table) == (files_per_table - 1) {
+                reader.seek(io::SeekFrom::Start(next_table_offset as u64))?;
+                next_table_offset = reader.read_u32::<LittleEndian>()?;
+            }
+        }
+
+        Ok(ZfsFile {
+            version,
+            max_filename_len,
+            files
+        })
+    }
+
+
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,13 +19,17 @@
 #![cfg_attr(feature = "set-timestamps", allow(stable_features))]
 #![cfg_attr(feature = "set-timestamps", feature(file_set_times))]
 
+#[cfg(feature = "png")]
 extern crate png;
 extern crate unciv;
 use std::fs::File;
+#[cfg(feature = "png")]
 use std::io::Read;
+#[cfg(feature = "png")]
 use std::io::Seek;
 use std::io::Write;
 
+#[cfg(feature = "png")]
 pub fn save_rim_image(entry : &unciv::ZfsEntry, reader : &mut (impl Read + Seek)) -> std::io::Result<()> {
     let rim_image = entry.read_rim_image(reader)?;
 
@@ -63,7 +67,8 @@ fn main() {
     let zfs_file = unciv::ZfsFile::from_stream(&mut file).unwrap();
 
     for entry in zfs_file.files {
-        if entry.name.ends_with(".rim") {
+        if cfg!(feature = "png") && entry.name.ends_with(".rim") {
+            #[cfg(feature = "png")]
             save_rim_image(&entry, &mut file).unwrap();
         } else {
             let data = entry.read_data(&mut file).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,185 +16,33 @@
  * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#![cfg_attr(feature = "set-timestamps", allow(stable_features))]
 #![cfg_attr(feature = "set-timestamps", feature(file_set_times))]
 
-extern crate byteorder;
 extern crate png;
-use byteorder::{LittleEndian, ReadBytesExt};
+extern crate unciv;
 use std::fs::File;
-use std::io::Seek;
-use std::io;
 use std::io::Read;
+use std::io::Seek;
 use std::io::Write;
 
-fn convert_555_888<W: std::io::Write>(reader : &mut impl Read, writer: &mut png::StreamWriter<W>) {
-    let px555 = reader.read_u16::<LittleEndian>().unwrap();
-    let red = (px555 >> 10) & 31;
-    let green = (px555 >> 5) & 31;
-    let blue = (px555 >> 0) & 31;
-    let rgb = [(red << 3) as u8, (green << 3) as u8, (blue << 3) as u8, 255u8];
-    writer.write(&rgb).unwrap();
-}
+pub fn save_rim_image(entry : &unciv::ZfsEntry, reader : &mut (impl Read + Seek)) -> std::io::Result<()> {
+    let rim_image = entry.read_rim_image(reader)?;
 
-fn convert_565_888<W: std::io::Write>(reader : &mut impl Read, writer: &mut png::StreamWriter<W>) {
-    let px555 = reader.read_u16::<LittleEndian>().unwrap();
-    let red = (px555 >> 11) & 31;
-    let green = (px555 >> 5) & 63;
-    let blue = (px555 >> 0) & 31;
-    let rgb = [(red << 3) as u8, (green << 2) as u8, (blue << 3) as u8, 255 as u8];
-    writer.write(&rgb).unwrap();
-}
 
-struct ZfsEntry
-{
-    name : String,
-    offset : usize,
-    size : usize,
-    timestamp : std::time::SystemTime,
-}
+    let out_file = File::create(format!("{}.png", &entry.name))?;
+    {
+        let mut png_encoder = png::Encoder::new(&out_file, rim_image.width as u32, rim_image.height as u32);
+        // Note: Newer versions of the 'png' library call this 'Rgba'.
+        png_encoder.set_color(png::ColorType::RGBA);
+        png_encoder.set_depth(png::BitDepth::Eight);
 
-impl ZfsEntry
-{
-    fn get_data(&self, reader : &mut (impl Read + Seek)) -> io::Result<Vec<u8>> {
-        let mut buffer = vec![0; self.size];
-        reader.seek(io::SeekFrom::Start(self.offset as u64))?;
-        reader.read(&mut buffer)?;
-        Ok(buffer)
+        let mut px_writer = png_encoder.write_header()?;
+        px_writer.write_image_data(&rim_image.to_rgba_bytes())?;
     }
-    
-    fn extract_file(&self, reader : &mut (impl Read + Seek)) -> io::Result<()> {
-        let data = self.get_data(reader)?;
-        println!("Extracting file \"{}\"…", self.name);
-        let mut out_file = File::create(&self.name)?;
-        out_file.write_all(&data)?;
-        #[cfg(feature = "set-timestamps")]
-        out_file.set_modified(self.timestamp)?;
-        Ok(())
-    }
-    
-    fn extract_rim_image(&self, reader : &mut (impl Read + Seek)) -> io::Result<()> {
-        reader.seek(io::SeekFrom::Start(self.offset as u64))?;
-        
-        let rim_sig = reader.read_u32::<LittleEndian>()?;
-        
-        // 'RIMF'
-        if rim_sig != 0x464d4952 {
-            return Err(io::Error::new(io::ErrorKind::Other, "Invalid RIM signature"));
-        }
-        
-        let rim_ver = reader.read_u32::<LittleEndian>()?;
-        let rim_width = reader.read_u16::<LittleEndian>()?;
-        let rim_height = reader.read_u16::<LittleEndian>()?;
-        let rim_pitch = reader.read_u16::<LittleEndian>()?;
-        let rim_fmt = reader.read_u16::<LittleEndian>()?;
-        
-        println!("Converting RIM v{} ({}) image \"{}\" ({}×{})…", rim_ver, if rim_fmt == 0 { "RGB555" } else { "RGB565" }, self.name, rim_width, rim_height);
-        
-        // Note: Apparently this doesn't need to be mutable? Can't think of why, though: it has state (e.g. offset) we're mutating.
-        let mut out_file = File::create(format!("{}.png", &self.name))?;
-        {
-            let mut png_encoder = png::Encoder::new(&out_file, rim_width as u32, rim_height as u32);
-            // Note: Newer versions of the 'png' library call this 'Rgba'.
-            png_encoder.set_color(png::ColorType::RGBA);
-            png_encoder.set_depth(png::BitDepth::Eight);
-            
-            let mut px_writer = png_encoder.write_header()?;
-            // Note: Newer versions of the 'png' library have this return a result, so needs a '?'.
-            let mut stream_writer = px_writer.stream_writer();
-            for _line_num in 0..rim_height {
-                for _px in 0..rim_width {
-                    if rim_fmt == 0 {
-                        convert_555_888(reader, &mut stream_writer);
-                    } else if rim_fmt == 1 {
-                        convert_565_888(reader, &mut stream_writer);
-                    }
-
-                }
-                if rim_width * 2 < rim_pitch {
-                    reader.seek(io::SeekFrom::Current((rim_pitch - rim_width * 2) as i64))?;
-                }
-            }
-        }
-        #[cfg(feature = "set-timestamps")]
-        out_file.set_modified(self.timestamp)?;
-        Ok(())
-    }
-}
-
-struct ZfsFile
-{
-    _version : u32,
-    _max_filename_len : u32,
-    files : Vec::<ZfsEntry>,
-}
-
-impl ZfsFile
-{
-    fn from_stream(reader : &mut (impl Read + Seek)) -> io::Result<ZfsFile> {
-        let sig = reader.read_u32::<LittleEndian>()?;
-        // 'ZFS3'
-        if sig != 0x3353465a {
-            return Err(io::Error::new(io::ErrorKind::Other, "Invalid ZFS signature"));
-        }
-        let version = reader.read_u32::<LittleEndian>()?;
-        let max_filename_len = reader.read_u32::<LittleEndian>()?;
-        let _unk1 = reader.read_u32::<LittleEndian>()?;
-        let num_files = reader.read_u32::<LittleEndian>()?;
-        let _unk2 = reader.read_u32::<LittleEndian>()?;
-        let filetable_offset = reader.read_u32::<LittleEndian>()?;
-
-
-        let mut files = Vec::<ZfsEntry>::new();
-
-        reader.seek(io::SeekFrom::Start(filetable_offset as u64))?;
-
-        let mut next_table_offset = reader.read_u32::<LittleEndian>()?;
-        for i in 0..num_files {
-            let mut raw_name = vec![0; max_filename_len as usize];
-            reader.read_exact(&mut raw_name)?;
-
-            if raw_name[0] == 0 {
-                break;
-            }
-
-            let file_name = String::from_utf8_lossy(&raw_name);
-            let file_name = file_name.trim_matches('\0');
-            let data_offset = reader.read_u32::<LittleEndian>()?;
-            let _unk3 = reader.read_u32::<LittleEndian>()?;
-            let data_size = reader.read_u32::<LittleEndian>()?;
-            let timestamp = reader.read_u32::<LittleEndian>()?;
-            let _flags = reader.read_u32::<LittleEndian>()?;
-
-            files.push(ZfsEntry{
-                name : file_name.to_string(),
-                offset : data_offset as usize,
-                size : data_size as usize,
-                timestamp: std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(timestamp as u64),
-            });
-
-            if (i % _unk1) == (_unk1 - 1) {
-                reader.seek(io::SeekFrom::Start(next_table_offset as u64))?;
-                next_table_offset = reader.read_u32::<LittleEndian>()?;
-            }
-        }
-
-        Ok(ZfsFile {
-            _version : version,
-            _max_filename_len : max_filename_len,
-            files
-        })
-    }
-    
-    fn extract_all(self, reader : &mut (impl Read + Seek)) -> io::Result<()> {
-        for i in self.files {
-            if i.name.ends_with(".rim") {
-                i.extract_rim_image(reader)?;
-            } else {
-                i.extract_file(reader)?;
-            }
-        }
-        Ok(())
-    }
+    #[cfg(feature = "set-timestamps")]
+    out_file.set_modified(entry.timestamp)?;
+    Ok(())
 }
 
 fn main() {
@@ -212,7 +60,18 @@ fn main() {
 
     let mut file = File::open(&args[1]).unwrap();
 
-    let zfs_file = ZfsFile::from_stream(&mut file).unwrap();
-    
-    zfs_file.extract_all(&mut file).unwrap();
+    let zfs_file = unciv::ZfsFile::from_stream(&mut file).unwrap();
+
+    for entry in zfs_file.files {
+        if entry.name.ends_with(".rim") {
+            save_rim_image(&entry, &mut file).unwrap();
+        } else {
+            let data = entry.read_data(&mut file).unwrap();
+            println!("Extracting file \"{}\"…", entry.name);
+            let mut out_file = File::create(entry.name).unwrap();
+            out_file.write_all(&data).unwrap();
+            #[cfg(feature = "set-timestamps")]
+            out_file.set_modified(entry.timestamp).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
Some basic refactoring to split unciv into a library, which can be used by other code, and a binary which relies on it.

The code for writing files (including the png files for RIM images) is now a part of the binary, the libary technically doesn't depend on png (though Cargo.toml hasn't been updated to mention this).

The API is not perfect, but the binary should give a basic example on how to use it. ZfsEntry structs refer to an entry before it is read: you need to provide a reader to the same file to get its data. On the other hand, RimImage _does_ contain the data, once you load it from a ZfsEntry, there's no need to keep the file/reader around.

This is step one for getting the code into crates.io (#1) — feedback on the API is greatly desired. Also, there are several documentation cleanups, etc, which will happen once we've got an API which is not terrible to use.